### PR TITLE
Link token

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ end
 
 Then to auth with Cronofy you would navigate to `/auth/cronofy`.
 
+#### Explicit Linking
+
+Cronofy supports [explicit linking of calendar accounts](https://www.cronofy.com/developers/api/alpha/#auth-explicit-linking) by passing a `link_token` to the auth flow. This strategy supports that token be passed as a query string parameter to the auth redirect.
+
+```
+/auth/cronofy?link_token=hga672376....
+```
+
 ### Configuration
 
 Configurable options

--- a/lib/omniauth-cronofy/version.rb
+++ b/lib/omniauth-cronofy/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Cronofy
-    VERSION = '0.9.0'.freeze
+    VERSION = '0.10.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/cronofy.rb
+++ b/lib/omniauth/strategies/cronofy.rb
@@ -46,6 +46,17 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get("#{::OmniAuth::Strategies::Cronofy.api_url}/v1/account").parsed['account']
       end
+
+      alias :old_request_phase :request_phase
+
+      def request_phase
+        link_token = session['omniauth.params']['link_token']
+        if link_token && !link_token.empty?
+          options[:authorize_params] ||= {}
+          options[:authorize_params].merge!(:link_token => link_token)
+        end
+        old_request_phase
+      end
     end
   end
 end

--- a/lib/omniauth/strategies/cronofy.rb
+++ b/lib/omniauth/strategies/cronofy.rb
@@ -47,15 +47,13 @@ module OmniAuth
         @raw_info ||= access_token.get("#{::OmniAuth::Strategies::Cronofy.api_url}/v1/account").parsed['account']
       end
 
-      alias :old_request_phase :request_phase
-
       def request_phase
         link_token = session['omniauth.params']['link_token']
         if link_token && !link_token.empty?
           options[:authorize_params] ||= {}
           options[:authorize_params].merge!(:link_token => link_token)
         end
-        old_request_phase
+        super
       end
     end
   end


### PR DESCRIPTION
Allow a `link_token` to be passed as a query string parameter to the main auth redirect.