### PR TITLE
Support data center option

### DIFF
--- a/lib/omniauth-cronofy.rb
+++ b/lib/omniauth-cronofy.rb
@@ -1,5 +1,6 @@
 require "omniauth"
 require "omniauth-oauth2"
 require "omniauth-cronofy/version"
+require "omniauth/strategies/cronofy_base"
 require "omniauth/strategies/cronofy"
 require "omniauth/strategies/cronofy_service_account"

--- a/lib/omniauth/strategies/cronofy.rb
+++ b/lib/omniauth/strategies/cronofy.rb
@@ -1,43 +1,9 @@
 module OmniAuth
   module Strategies
-    class Cronofy < OmniAuth::Strategies::OAuth2
+    class Cronofy < CronofyBase
       option :name, "cronofy"
 
-      def self.api_url
-        @api_url ||= (ENV['CRONOFY_API_URL'] || data_centre_api_url || "https://api.cronofy.com")
-      end
-
-      def self.data_centre_api_url
-        case ENV['CRONOFY_DATA_CENTRE']
-        when 'de'
-          "https://api-#{ENV['CRONOFY_DATA_CENTRE']}.cronofy.com"
-        end
-      end
-
-      def self.api_url=(value)
-        @api_url = value
-      end
-
-      def self.app_url
-        @app_url ||= (ENV['CRONOFY_APP_URL'] || data_centre_app_url || "https://app.cronofy.com")
-      end
-
-      def self.data_centre_app_url
-        case ENV['CRONOFY_DATA_CENTRE']
-        when 'de'
-          "https://app-#{ENV['CRONOFY_DATA_CENTRE']}.cronofy.com"
-        end
-      end
-
-      def self.app_url=(value)
-        @app_url = value
-      end
-
-      option :client_options, {
-        :site => ::OmniAuth::Strategies::Cronofy.app_url
-      }
-
-      uid{ raw_info['account_id'] }
+      uid { raw_info['account_id'] }
 
       info do
         {
@@ -58,7 +24,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get("#{::OmniAuth::Strategies::Cronofy.api_url}/v1/account").parsed['account']
+        @raw_info ||= access_token.get("#{client_options[:api_url]}/v1/account").parsed['account']
       end
     end
   end

--- a/lib/omniauth/strategies/cronofy_base.rb
+++ b/lib/omniauth/strategies/cronofy_base.rb
@@ -1,0 +1,58 @@
+module OmniAuth
+  module Strategies
+    class CronofyBase < OmniAuth::Strategies::OAuth2
+      option :data_center, nil
+
+      def api_url
+        ENV['CRONOFY_API_URL'] || data_center_url(:api, data_center_env) || "https://api.cronofy.com"
+      end
+
+      def app_url
+        ENV['CRONOFY_APP_URL'] || data_center_url(:app, data_center_env) || "https://app.cronofy.com"
+      end
+
+      def data_center_env
+        ENV['CRONOFY_DATA_CENTER'] || ENV['CRONOFY_DATA_CENTRE']
+      end
+
+      def data_center_url(type, value)
+        case value.to_s
+        when 'de'
+          "https://#{type}-#{value}.cronofy.com"
+        end
+      end
+
+      def client_options
+        client_options = deep_symbolize(options.client_options)
+
+        unless client_options[:site]
+          if options.data_center
+            client_options[:site] = data_center_url(:app, options.data_center)
+          end
+
+          unless client_options[:site]
+            client_options[:site] = app_url
+          end
+        end
+
+        unless client_options[:api_url]
+          if options.data_center
+            client_options[:api_url] = data_center_url(:api, options.data_center)
+          end
+
+          unless client_options[:api_url]
+            client_options[:api_url] = api_url
+          end
+        end
+
+        log :debug, "site: #{client_options[:site]}, api_url: #{client_options[:api_url]}"
+
+        client_options
+      end
+
+      def client
+        ::OAuth2::Client.new(options.client_id, options.client_secret, client_options)
+      end
+    end
+  end
+end

--- a/lib/omniauth/strategies/cronofy_service_account.rb
+++ b/lib/omniauth/strategies/cronofy_service_account.rb
@@ -1,11 +1,10 @@
 module OmniAuth
   module Strategies
-    class CronofyServiceAccount < OmniAuth::Strategies::OAuth2
+    class CronofyServiceAccount < CronofyBase
       option :name, "cronofy_service_account"
 
       option :client_options, {
-        :site => ::OmniAuth::Strategies::Cronofy.app_url,
-        :authorize_url => "#{::OmniAuth::Strategies::Cronofy.app_url}/enterprise_connect/oauth/authorize",
+        :authorize_url => "/enterprise_connect/oauth/authorize",
       }
 
       def request_phase
@@ -13,7 +12,7 @@ module OmniAuth
         super
       end
 
-      uid{ raw_info['sub'] }
+      uid { raw_info['sub'] }
 
       info do
         {
@@ -32,7 +31,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get("#{::OmniAuth::Strategies::Cronofy.api_url}/v1/userinfo").parsed
+        @raw_info ||= access_token.get("#{client_options[:api_url]}/v1/userinfo").parsed
       end
     end
   end


### PR DESCRIPTION
Supports data center being set via `CRONOFY_DATA_CENTER` environment variable (and `CRONOFY_DATA_CENTRE` for backwards compatibility) but also via a `data_center` option at the point of configuration, eg:

```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :cronofy, ENV["CRONOFY_CLIENT_ID"], ENV["CRONOFY_CLIENT_SECRET"], {
    data_center: :de,
    scope: "create_event delete_event create_calendar read_events"
  }
end
```