### PR TITLE
Loosen omniauth dependency version requirement to allow latest security patches

### DIFF
--- a/omniauth-cronofy.gemspec
+++ b/omniauth-cronofy.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "omniauth", "~> 1.2"
+  spec.add_dependency "omniauth", ">= 1.2"
   spec.add_dependency "omniauth-oauth2", "~> 1.3"
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
### Context

`omniauth` gem had a version bump recently which included a fix to [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284).

Unfortunately it is not possible to update it in the projects which use omniauth-cronofy

### Solution

Loosen omniauth dependency version requirement to allow usage of latest `omniauth` gem code